### PR TITLE
add accumulator tank to limit inverted flight

### DIFF
--- a/MiG-21bis-set.xml
+++ b/MiG-21bis-set.xml
@@ -224,6 +224,7 @@
 			<tank n="11"><name>Ventral Drop Tank</name></tank>
 			<tank n="12"><name>Left Drop Tank</name></tank>
 			<tank n="13"><name>Right Drop Tank</name></tank>
+			<tank n="14"><name>Accumulator</name></tank>
 		</fuel>
 	</consumables>
 

--- a/MiG-21bis.xml
+++ b/MiG-21bis.xml
@@ -203,7 +203,7 @@
       <y>   0.00 </y>
       <z>   0.00 </z>
     </location>
-    <feed>2</feed>
+    <feed>14</feed>
     <thruster file="direct">
      <location unit="IN">
        <x> 263.40 </x>
@@ -256,7 +256,7 @@
   	<!-- Tanks:
 	0 - internal
 	1 - internal
-	2 - internal
+	2 - internal (Main)
 	3 - internal
 	4 - internal
 	5 - internal
@@ -268,6 +268,7 @@
 	11 - ventral drop tank
 	12 - left drop tank
 	13 - right drop tank
+	14 - accumulator (inside Main tank)
 	
 	***** FUEL AMOUNTS PER TANK ARE FICTIONAL ******* but the total fuel matches
 	***** LOCATIONS ARE ESTIMATES ***** i didn't have a map of tank 1 is here, tank 2 is there. just a cutaway.
@@ -308,8 +309,8 @@
      </location>
      <priority>2</priority>
      <density>6.5</density>
-     <capacity unit="LBS"> 466.4 </capacity>
-     <contents unit="LBS"> 440 </contents>
+     <capacity unit="LBS"> 410.4 </capacity>
+     <contents unit="LBS"> 384 </contents>
      <standpipe unit="LBS"> 100 </standpipe> 
   </tank>
   
@@ -453,6 +454,22 @@
      <capacity unit="LBS"> 850 </capacity>
      <contents unit="LBS"> 0 </contents>
   </tank>
+
+<!-- accumulator - inside tank 3 -->
+
+  <tank type="FUEL" number="14">
+     <location unit="M">
+       <x>  -0.50 </x>
+       <y>   0.00 </y>
+       <z>   0.50 </z>
+     </location>
+     <priority>1</priority>
+     <density>6.5</density>
+     <capacity unit="LBS"> 56 </capacity>
+     <contents unit="LBS"> 56 </contents>
+     <standpipe unit="LBS"> 0 </standpipe> 
+  </tank>
+  
 
   <dump-rate unit="LBS/MIN"> 1500 </dump-rate>
  </propulsion>

--- a/Systems/fuel.xml
+++ b/Systems/fuel.xml
@@ -18,6 +18,7 @@
 	11 - ventral drop tank
 	12 - left drop tank
 	13 - right drop tank
+	14 - accumulator
 	-->
 	
 	  <!--all the time:
@@ -25,7 +26,8 @@
   fuel flows from 7 to 2
   level the fuel between 4, 5, and 6
   fuel in 2 pumps into 3
-  fuel in 3 goes straight to engine
+  fuel in 3 goes straight to engine, via accumulator
+  accumulator feeds the engine in inverted flight
   
   ventral drop tank flows into 2
   wing drop tanks flow into 2
@@ -33,6 +35,8 @@
   #4,5 flow into #1
   #1,2 emptied
   #3 emptied-->
+
+	<property value="1">propulsion/tank[2]/accumulator-valve</property>
 	
 	<channel name="Fuel System">
 	
@@ -93,7 +97,7 @@
 			<test logic="AND" value="-15">
 				propulsion/tank[4]/contents-lbs gt 1
 				propulsion/tank[4]/contents-lbs gt propulsion/tank[3]/contents-lbs
-				propulsion/tank[3]/contents-lbs lt 349
+				propulsion/tank[3]/contents-lbs lt 319
 			</test>
 			<output>propulsion/tank[4]/levelling-flow-to-3</output>
 		</switch>
@@ -124,7 +128,7 @@
 			<default value="0"/>
 			<test logic="AND" value="-15">
 				propulsion/tank[1]/contents-lbs gt 1
-				propulsion/tank[2]/contents-lbs lt 463
+				propulsion/tank[2]/contents-lbs lt 407
 			</test>
 			<output>propulsion/tank[1]/pumping-flow-to-2</output>
 		</switch>
@@ -235,6 +239,18 @@
 			<output>propulsion/tank[4]/pumping-flow-to-0</output>
 		</switch>
 
+		<!-- accumulator fed from 3 when G<-0.5 -->
+
+		<switch name="trash/fuelaccumulator">
+			<default value="-15"/>
+			<test logic="OR" value="0">
+				propulsion/tank[2]/accumulator-valve EQ 0 
+				propulsion/tank[2]/contents-lbs LE 1
+				propulsion/tank[14]contents-lbs GE 54
+				accelerations/Nz LE -0.5
+			</test>
+			<output>propulsion/tank[2]/flow-to-accumulator</output>
+		</switch>
 		
 		<!-- inputs/outputs -->
 		
@@ -268,6 +284,7 @@
 		<!-- tank 2 -->
 		<summer name="trash/fuelrefuel18">
 			<input>-propulsion/tank[1]/pumping-flow-to-2</input>
+			<input>propulsion/tank[2]/flow-to-accumulator</input>
 			<output>propulsion/tank[2]/external-flow-rate-pps</output>
 		</summer>
 		
@@ -342,6 +359,12 @@
 		<summer name="trash/fuelrefuel28">
 			<input>propulsion/tank[13]/pumping-flow-to-1</input>
 			<output>propulsion/tank[13]/external-flow-rate-pps</output>
+		</summer>
+
+		<!-- tank 14 accumulator -->
+		<summer name="trash/fuelaccumulator2">
+			<input>-propulsion/tank[2]/flow-to-accumulator</input>
+			<output>propulsion/tank[14]/external-flow-rate-pps</output>
 		</summer>
 
 	</channel>

--- a/Systems/fuel.xml
+++ b/Systems/fuel.xml
@@ -246,7 +246,7 @@
 			<test logic="OR" value="0">
 				propulsion/tank[2]/accumulator-valve EQ 0 
 				propulsion/tank[2]/contents-lbs LE 1
-				propulsion/tank[14]contents-lbs GE 54
+				propulsion/tank[14]/contents-lbs GE 54
 				accelerations/Nz LE -0.5
 			</test>
 			<output>propulsion/tank[2]/flow-to-accumulator</output>


### PR DESCRIPTION
 - accumulator added for 5 seconds afterburner limit (more than 15 secs
mil power)
 - feed changed to accumulator
 - main tank reduced by size of accumulator
 - logic for main to accumulator flow
 - summers for main & accumulator